### PR TITLE
Update to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "plain"
 version = "0.2.3"
+edition = "2018"
 authors = ["jzr"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,33 +58,33 @@
 //! unsafe impl Plain for ELF64Header {}
 //!
 //! impl ELF64Header {
-//! 	fn from_bytes(buf: &[u8]) -> &ELF64Header {
-//!			plain::from_bytes(buf).expect("The buffer is either too short or not aligned!")
-//!		}
+//!     fn from_bytes(buf: &[u8]) -> &ELF64Header {
+//!             plain::from_bytes(buf).expect("The buffer is either too short or not aligned!")
+//!         }
 //!
-//!		fn from_mut_bytes(buf: &mut [u8]) -> &mut ELF64Header {
-//!			plain::from_mut_bytes(buf).expect("The buffer is either too short or not aligned!")
-//!		}
+//!         fn from_mut_bytes(buf: &mut [u8]) -> &mut ELF64Header {
+//!             plain::from_mut_bytes(buf).expect("The buffer is either too short or not aligned!")
+//!         }
 //!
-//!		fn copy_from_bytes(buf: &[u8]) -> ELF64Header {
-//!			let mut h = ELF64Header::default();
-//!			h.copy_from_bytes(buf).expect("The buffer is too short!");
-//!			h
-//!		}
+//!         fn copy_from_bytes(buf: &[u8]) -> ELF64Header {
+//!             let mut h = ELF64Header::default();
+//!             h.copy_from_bytes(buf).expect("The buffer is too short!");
+//!             h
+//!         }
 //! }
 //!
 //! # fn process_elf(elf: &ELF64Header) {}
 //!
 //! // Conditional copying for ultimate hackery.
 //! fn opportunistic_elf_processing(buf: &[u8]) {
-//! 	if plain::is_aligned::<ELF64Header>(buf) {
+//!     if plain::is_aligned::<ELF64Header>(buf) {
 //!         // No copy necessary.
-//!			let elf_ref = ELF64Header::from_bytes(buf);
-//!			process_elf(elf_ref);
+//!             let elf_ref = ELF64Header::from_bytes(buf);
+//!             process_elf(elf_ref);
 //!     } else {
 //!         // Not aligned properly, copy to stack first.
-//!			let elf = ELF64Header::copy_from_bytes(buf);
-//!			process_elf(&elf);
+//!             let elf = ELF64Header::copy_from_bytes(buf);
+//!             process_elf(&elf);
 //!     }
 //! }
 //!
@@ -110,10 +110,10 @@
 //! }
 //!
 //! fn array_from_unaligned_bytes(buf: &[u8]) -> Vec<ArrayEntry> {
-//!		let length = buf.len() / mem::size_of::<ArrayEntry>();
-//! 	let mut result = vec![ArrayEntry::default(); length];
-//!  	(&mut result).copy_from_bytes(buf).expect("Cannot fail here.");
-//!		result
+//!    let length = buf.len() / mem::size_of::<ArrayEntry>();
+//!    let mut result = vec![ArrayEntry::default(); length];
+//!    (&mut result).copy_from_bytes(buf).expect("Cannot fail here.");
+//!    result
 //! }
 //!
 //! # fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,6 @@
 //!
 //! ```
 //!
-//! extern crate plain;
 //! use plain::Plain;
 //! use std::mem;
 //!
@@ -140,15 +139,16 @@
 #![no_std]
 
 mod error;
-pub use error::Error;
+pub use crate::error::Error;
 
 mod plain;
-pub use plain::Plain;
+pub use crate::plain::Plain;
 
 mod methods;
-pub use methods::{as_bytes, as_mut_bytes, copy_from_bytes, from_bytes, from_mut_bytes, is_aligned,
-                  slice_from_bytes, slice_from_bytes_len, slice_from_mut_bytes,
-                  slice_from_mut_bytes_len};
+pub use crate::methods::{
+    as_bytes, as_mut_bytes, copy_from_bytes, from_bytes, from_mut_bytes, is_aligned,
+    slice_from_bytes, slice_from_bytes_len, slice_from_mut_bytes, slice_from_mut_bytes_len,
+};
 
 #[cfg(test)]
 #[macro_use]

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -18,7 +18,7 @@ fn check_alignment<T>(bytes: &[u8]) -> Result<(), Error> {
 }
 
 #[inline(always)]
-fn check_length<T>(bytes: &[u8], len: usize) -> Result<(), Error> {
+const fn check_length<T>(bytes: &[u8], len: usize) -> Result<(), Error> {
     if mem::size_of::<T>() > 0 && (bytes.len() / mem::size_of::<T>()) < len {
         Err(Error::TooShort)
     } else {
@@ -164,7 +164,7 @@ where
 {
     check_alignment::<T>(bytes)?;
     check_length::<T>(bytes, len)?;
-    Ok(unsafe { slice::from_raw_parts_mut(bytes.as_ptr() as *mut T, len) })
+    Ok(unsafe { slice::from_raw_parts_mut(bytes.as_mut_ptr().cast::<T>(), len) })
 }
 
 /// Copies data from a byte slice into existing memory.

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -5,7 +5,7 @@ use crate::{Error, Plain};
 /// Check if a byte slice is aligned suitably for type T.
 #[inline]
 pub fn is_aligned<T>(bytes: &[u8]) -> bool {
-    bytes.as_ptr().align_offset(mem::align_of::<T>()) == 0
+    ((bytes.as_ptr() as usize) % mem::align_of::<T>()) == 0
 }
 
 #[inline(always)]

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -5,7 +5,7 @@ use crate::{Error, Plain};
 /// Check if a byte slice is aligned suitably for type T.
 #[inline]
 pub fn is_aligned<T>(bytes: &[u8]) -> bool {
-    ((bytes.as_ptr() as usize) % mem::align_of::<T>()) == 0
+    bytes.as_ptr().align_offset(mem::align_of::<T>()) == 0
 }
 
 #[inline(always)]

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -1,6 +1,6 @@
 use core::{mem, slice};
 
-use {Error, Plain};
+use crate::{Error, Plain};
 
 /// Check if a byte slice is aligned suitably for type T.
 #[inline]
@@ -72,8 +72,8 @@ pub fn from_bytes<T>(bytes: &[u8]) -> Result<&T, Error>
 where
     T: Plain,
 {
-    try!(check_alignment::<T>(bytes));
-    try!(check_length::<T>(bytes, 1));
+    check_alignment::<T>(bytes)?;
+    check_length::<T>(bytes, 1)?;
     Ok(unsafe { &*(bytes.as_ptr() as *const T) })
 }
 
@@ -110,7 +110,6 @@ where
     slice_from_bytes_len(bytes, len)
 }
 
-
 /// Same as [`slice_from_bytes()`](fn.slice_from_bytes.html),
 /// except that it takes explicit length of the result slice.
 ///
@@ -122,11 +121,9 @@ pub fn slice_from_bytes_len<T>(bytes: &[u8], len: usize) -> Result<&[T], Error>
 where
     T: Plain,
 {
-    try!(check_alignment::<T>(bytes));
-    try!(check_length::<T>(bytes, len));
-    Ok(unsafe {
-        slice::from_raw_parts(bytes.as_ptr() as *const T, len)
-    })
+    check_alignment::<T>(bytes)?;
+    check_length::<T>(bytes, len)?;
+    Ok(unsafe { slice::from_raw_parts(bytes.as_ptr() as *const T, len) })
 }
 
 /// See [`from_bytes()`](fn.from_bytes.html).
@@ -138,8 +135,8 @@ pub fn from_mut_bytes<T>(bytes: &mut [u8]) -> Result<&mut T, Error>
 where
     T: Plain,
 {
-    try!(check_alignment::<T>(bytes));
-    try!(check_length::<T>(bytes, 1));
+    check_alignment::<T>(bytes)?;
+    check_length::<T>(bytes, 1)?;
     Ok(unsafe { &mut *(bytes.as_mut_ptr() as *mut T) })
 }
 
@@ -165,11 +162,9 @@ pub fn slice_from_mut_bytes_len<T>(bytes: &mut [u8], len: usize) -> Result<&mut 
 where
     T: Plain,
 {
-    try!(check_alignment::<T>(bytes));
-    try!(check_length::<T>(bytes, len));
-    Ok(unsafe {
-        slice::from_raw_parts_mut(bytes.as_ptr() as *mut T, len)
-    })
+    check_alignment::<T>(bytes)?;
+    check_length::<T>(bytes, len)?;
+    Ok(unsafe { slice::from_raw_parts_mut(bytes.as_ptr() as *mut T, len) })
 }
 
 /// Copies data from a byte slice into existing memory.

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -32,7 +32,7 @@ pub unsafe fn as_bytes<S>(s: &S) -> &[u8]
 where
     S: ?Sized,
 {
-    let bptr = s as *const S as *const u8;
+    let bptr = (s as *const S).cast::<u8>();
     let bsize = mem::size_of_val(s);
     slice::from_raw_parts(bptr, bsize)
 }
@@ -44,7 +44,7 @@ pub unsafe fn as_mut_bytes<S>(s: &mut S) -> &mut [u8]
 where
     S: Plain + ?Sized,
 {
-    let bptr = s as *mut S as *mut u8;
+    let bptr = (s as *mut S).cast::<u8>();
     let bsize = mem::size_of_val(s);
     slice::from_raw_parts_mut(bptr, bsize)
 }
@@ -74,7 +74,7 @@ where
 {
     check_alignment::<T>(bytes)?;
     check_length::<T>(bytes, 1)?;
-    Ok(unsafe { &*(bytes.as_ptr() as *const T) })
+    Ok(unsafe { &*(bytes.as_ptr().cast::<T>()) })
 }
 
 /// Similar to [`from_bytes()`](fn.from_bytes.html),
@@ -123,7 +123,7 @@ where
 {
     check_alignment::<T>(bytes)?;
     check_length::<T>(bytes, len)?;
-    Ok(unsafe { slice::from_raw_parts(bytes.as_ptr() as *const T, len) })
+    Ok(unsafe { slice::from_raw_parts(bytes.as_ptr().cast::<T>(), len) })
 }
 
 /// See [`from_bytes()`](fn.from_bytes.html).
@@ -137,7 +137,7 @@ where
 {
     check_alignment::<T>(bytes)?;
     check_length::<T>(bytes, 1)?;
-    Ok(unsafe { &mut *(bytes.as_mut_ptr() as *mut T) })
+    Ok(unsafe { &mut *(bytes.as_mut_ptr().cast::<T>()) })
 }
 
 /// See [`slice_from_bytes()`](fn.slice_from_bytes.html).

--- a/src/plain.rs
+++ b/src/plain.rs
@@ -1,4 +1,7 @@
-use Error;
+use crate::{
+    copy_from_bytes, from_bytes, from_mut_bytes, slice_from_bytes, slice_from_bytes_len,
+    slice_from_mut_bytes, slice_from_mut_bytes_len, Error,
+};
 
 /// A trait for plain data types that can be safely read from a byte slice.
 ///
@@ -24,27 +27,16 @@ use Error;
 ///
 pub unsafe trait Plain {
     #[inline(always)]
+    fn copy_from_bytes(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        copy_from_bytes(self, bytes)
+    }
+
+    #[inline(always)]
     fn from_bytes(bytes: &[u8]) -> Result<&Self, Error>
     where
         Self: Sized,
     {
-        ::from_bytes(bytes)
-    }
-
-    #[inline(always)]
-    fn slice_from_bytes(bytes: &[u8]) -> Result<&[Self], Error>
-    where
-        Self: Sized,
-    {
-        ::slice_from_bytes(bytes)
-    }
-
-    #[inline(always)]
-    fn slice_from_bytes_len(bytes: &[u8], len: usize) -> Result<&[Self], Error>
-    where
-        Self: Sized,
-    {
-        ::slice_from_bytes_len(bytes, len)
+        from_bytes(bytes)
     }
 
     #[inline(always)]
@@ -52,7 +44,23 @@ pub unsafe trait Plain {
     where
         Self: Sized,
     {
-        ::from_mut_bytes(bytes)
+        from_mut_bytes(bytes)
+    }
+
+    #[inline(always)]
+    fn slice_from_bytes(bytes: &[u8]) -> Result<&[Self], Error>
+    where
+        Self: Sized,
+    {
+        slice_from_bytes(bytes)
+    }
+
+    #[inline(always)]
+    fn slice_from_bytes_len(bytes: &[u8], len: usize) -> Result<&[Self], Error>
+    where
+        Self: Sized,
+    {
+        slice_from_bytes_len(bytes, len)
     }
 
     #[inline(always)]
@@ -60,7 +68,7 @@ pub unsafe trait Plain {
     where
         Self: Sized,
     {
-        ::slice_from_mut_bytes(bytes)
+        slice_from_mut_bytes(bytes)
     }
 
     #[inline(always)]
@@ -68,12 +76,7 @@ pub unsafe trait Plain {
     where
         Self: Sized,
     {
-        ::slice_from_mut_bytes_len(bytes, len)
-    }
-
-    #[inline(always)]
-    fn copy_from_bytes(&mut self, bytes: &[u8]) -> Result<(), Error> {
-        ::copy_from_bytes(self, bytes)
+        slice_from_mut_bytes_len(bytes, len)
     }
 }
 
@@ -89,11 +92,7 @@ unsafe impl Plain for i32 {}
 unsafe impl Plain for i64 {}
 unsafe impl Plain for isize {}
 
-unsafe impl<S> Plain for [S]
-where
-    S: Plain,
-{
-}
+unsafe impl<S> Plain for [S] where S: Plain {}
 
 macro_rules! impl_array {
     ($($n:tt)+) => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,11 @@
 #![allow(dead_code)]
 
-use ::*;
 use core::mem;
+
+use crate::{
+    from_bytes, methods, slice_from_bytes, slice_from_bytes_len, slice_from_mut_bytes_len, Error,
+    Plain,
+};
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Eq, Clone, PartialEq)]
@@ -48,7 +52,7 @@ fn unaligned() {
     let b = vec![0u8; mem::size_of::<Dummy1>() + 1];
     let b = &b[1..];
 
-    let r = Dummy1::from_bytes(&b);
+    let r = Dummy1::from_bytes(b);
     assert!(r == Err(Error::BadAlignment));
 }
 


### PR DESCRIPTION
* Use Rust 2018 syntax.
* Use space instead of tabs in documentation. [relative clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#tabs_in_doc_comments)
* Use `pointer::cast` instead of `as`. [relative clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_as_ptr)
* Made `check_length` a `const fn` function.
* Use the `?` operator instead of deprecated `try!` macro.

In addition this PR solves a fail during the tests if tested with [`cargo miri`](https://github.com/rust-lang/miri).